### PR TITLE
Fix "multiple definition" errors with GCC 10

### DIFF
--- a/0c/list.c
+++ b/0c/list.c
@@ -1,4 +1,4 @@
-#define EXTERN
+#define EXTERN extern
 #include "gc.h"
 
 void

--- a/0c/mul.c
+++ b/0c/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/1c/list.c
+++ b/1c/list.c
@@ -1,4 +1,4 @@
-#define EXTERN
+#define EXTERN extern
 #include "gc.h"
 
 void

--- a/1c/mul.c
+++ b/1c/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/1l/asm.c
+++ b/1l/asm.c
@@ -1,7 +1,6 @@
 #include	"l.h"
 
 short	opa[20];
-short	*op;
 
 long
 entryvalue(void)

--- a/1l/l.h
+++ b/1l/l.h
@@ -187,7 +187,7 @@ EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	long	nsymbol;
 EXTERN	char*	noname;
-extern	short*	op;
+EXTERN	short*	op;
 EXTERN	char*	outfile;
 EXTERN	long	pc;
 EXTERN	char	simple[I_MASK];

--- a/1l/l.h
+++ b/1l/l.h
@@ -187,7 +187,7 @@ EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	long	nsymbol;
 EXTERN	char*	noname;
-EXTERN	short*	op;
+extern	short*	op;
 EXTERN	char*	outfile;
 EXTERN	long	pc;
 EXTERN	char	simple[I_MASK];

--- a/2c/list.c
+++ b/2c/list.c
@@ -1,4 +1,4 @@
-#define EXTERN
+#define EXTERN extern
 #include "gc.h"
 
 void

--- a/2c/mul.c
+++ b/2c/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/2l/asm.c
+++ b/2l/asm.c
@@ -1,7 +1,6 @@
 #include	"l.h"
 
 short	opa[20];
-short	*op;
 
 long
 entryvalue(void)

--- a/2l/l.h
+++ b/2l/l.h
@@ -179,7 +179,7 @@ EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	long	nsymbol;
 EXTERN	char*	noname;
-EXTERN	short*	op;
+extern	short*	op;
 EXTERN	char*	outfile;
 EXTERN	long	pc;
 EXTERN	char	simple[I_MASK];

--- a/2l/l.h
+++ b/2l/l.h
@@ -179,7 +179,7 @@ EXTERN	int	nerrors;
 EXTERN	long	nhunk;
 EXTERN	long	nsymbol;
 EXTERN	char*	noname;
-extern	short*	op;
+EXTERN	short*	op;
 EXTERN	char*	outfile;
 EXTERN	long	pc;
 EXTERN	char	simple[I_MASK];

--- a/5c/list.c
+++ b/5c/list.c
@@ -1,4 +1,4 @@
-#define	EXTERN
+#define	EXTERN extern
 #include "gc.h"
 
 void

--- a/5c/mul.c
+++ b/5c/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/7c/list.c
+++ b/7c/list.c
@@ -1,4 +1,4 @@
-#define	EXTERN
+#define	EXTERN extern
 #include "gc.h"
 
 void

--- a/7c/mul.c
+++ b/7c/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/7l/l.h
+++ b/7l/l.h
@@ -217,7 +217,7 @@ EXTERN	Prog*	datap;
 EXTERN	long	datsize;
 EXTERN	Prog*	etextp;
 EXTERN	Prog*	firstp;
-EXTERN	char*	noname;
+extern	char*	noname;
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
 EXTERN	char	literal[32];

--- a/7l/l.h
+++ b/7l/l.h
@@ -1,6 +1,10 @@
 #include	"../ld/ld.h"
 #include	"../7c/7.out.h"
 
+#ifndef EXTERN
+#define EXTERN extern
+#endif
+
 typedef	struct	Mask	Mask;
 typedef	struct	Optab	Optab;
 typedef	struct	Oprang	Oprang;
@@ -217,7 +221,6 @@ EXTERN	Prog*	datap;
 EXTERN	long	datsize;
 EXTERN	Prog*	etextp;
 EXTERN	Prog*	firstp;
-extern	char*	noname;
 EXTERN	Prog*	lastp;
 EXTERN	long	lcsize;
 EXTERN	char	literal[32];
@@ -235,6 +238,7 @@ EXTERN	char	xcmp[C_NCLASS][C_NCLASS];
 EXTERN	Prog	zprg;
 EXTERN	int	dtype;
 
+extern	char*	noname;
 extern	char*	anames[];
 extern	char*	cnames[];
 extern	Optab	optab[];

--- a/kc/list.c
+++ b/kc/list.c
@@ -1,4 +1,4 @@
-#define EXTERN
+#define EXTERN extern
 #include "gc.h"
 
 void

--- a/kc/mul.c
+++ b/kc/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/qa/a.h
+++ b/qa/a.h
@@ -55,7 +55,7 @@ struct	Sym
 };
 #define	S	((Sym*)0)
 
-struct
+EXTERN struct
 {
 	char*	p;
 	int	c;
@@ -71,7 +71,7 @@ struct	Io
 };
 #define	I	((Io*)0)
 
-struct
+EXTERN struct
 {
 	Sym*	sym;
 	short	type;

--- a/qc/list.c
+++ b/qc/list.c
@@ -1,4 +1,4 @@
-#define EXTERN
+#define EXTERN extern
 #include "gc.h"
 
 void

--- a/qc/mul.c
+++ b/qc/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/ql/l.h
+++ b/ql/l.h
@@ -86,7 +86,7 @@ struct	Optab
 	char	size;
 	char	param;
 };
-struct
+EXTERN struct
 {
 	Optab*	start;
 	Optab*	stop;

--- a/rc/exec.c
+++ b/rc/exec.c
@@ -1,6 +1,8 @@
 #include "rc.h"
 #include "getflags.h"
+#define EXTERN
 #include "exec.h"
+#undef EXTERN
 #include "io.h"
 #include "fns.h"
 /*

--- a/rc/exec.h
+++ b/rc/exec.h
@@ -1,3 +1,7 @@
+#ifndef EXTERN
+#define EXTERN extern
+#endif
+
 /*
  * Definitions used in the interpreter
  */
@@ -25,7 +29,7 @@ struct list{
 	word *words;
 	list *next;
 };
-word *newword(char *, word *), *copywords(word *, word *);
+EXTERN word *newword(char *, word *), *copywords(word *, word *);
 struct redir{
 	char type;			/* what to do */
 	short from, to;			/* what to do it to */
@@ -56,21 +60,21 @@ struct thread{
 	tree *treenodes;		/* tree nodes created by this process */
 	thread *ret;		/* who continues when this finishes */
 };
-thread *runq;
-code *codecopy(code*);
-code *codebuf;				/* compiler output */
-int ntrap;				/* number of outstanding traps */
-int trap[NSIG];				/* number of outstanding traps per type */
+EXTERN thread *runq;
+EXTERN code *codecopy(code*);
+EXTERN code *codebuf;				/* compiler output */
+EXTERN int ntrap;				/* number of outstanding traps */
+EXTERN int trap[NSIG];				/* number of outstanding traps per type */
 struct builtin{
 	char *name;
 	void (*fnc)(void);
 };
 extern struct builtin Builtin[];
-int eflagok;			/* kludge flag so that -e doesn't exit in startup */
-int havefork;
+EXTERN int eflagok;			/* kludge flag so that -e doesn't exit in startup */
+extern int havefork;
 
-void execcd(void), execwhatis(void), execeval(void), execexec(void);
-int execforkexec(void);
-void execexit(void), execshift(void);
-void execwait(void), execumask(void), execdot(void), execflag(void);
-void execfunc(var*), execcmds(io *);
+EXTERN void execcd(void), execwhatis(void), execeval(void), execexec(void);
+EXTERN int execforkexec(void);
+EXTERN void execexit(void), execshift(void);
+EXTERN void execwait(void), execumask(void), execdot(void), execflag(void);
+EXTERN void execfunc(var*), execcmds(io *);

--- a/rc/io.h
+++ b/rc/io.h
@@ -1,28 +1,32 @@
 #define	EOF	(-1)
 #define	NBUF	512
 
+#ifndef EXTERN
+#define EXTERN extern
+#endif
+
 struct io{
 	int	fd;
 	uchar	*bufp, *ebuf, *strp;
 	uchar	buf[NBUF];
 };
-io *err;
+EXTERN io *err;
 
-io *openfd(int), *openstr(void), *opencore(char *, int);
-int emptybuf(io*);
-void pchr(io*, int);
-int rchr(io*);
-int rutf(io*, char*, Rune*);
-void closeio(io*);
-void flush(io*);
-int fullbuf(io*, int);
-void pdec(io*, int);
-void poct(io*, unsigned);
-void pptr(io*, void*);
-void pquo(io*, char*);
-void pwrd(io*, char*);
-void pstr(io*, char*);
-void pcmd(io*, tree*);
-void pval(io*, word*);
-void pfnc(io*, thread*);
-void pfmt(io*, char*, ...);
+EXTERN io *openfd(int), *openstr(void), *opencore(char *, int);
+EXTERN int emptybuf(io*);
+EXTERN void pchr(io*, int);
+EXTERN int rchr(io*);
+EXTERN int rutf(io*, char*, Rune*);
+EXTERN void closeio(io*);
+EXTERN void flush(io*);
+EXTERN int fullbuf(io*, int);
+EXTERN void pdec(io*, int);
+EXTERN void poct(io*, unsigned);
+EXTERN void pptr(io*, void*);
+EXTERN void pquo(io*, char*);
+EXTERN void pwrd(io*, char*);
+EXTERN void pstr(io*, char*);
+EXTERN void pcmd(io*, tree*);
+EXTERN void pval(io*, word*);
+EXTERN void pfnc(io*, thread*);
+EXTERN void pfmt(io*, char*, ...);

--- a/rc/lex.c
+++ b/rc/lex.c
@@ -1,4 +1,7 @@
+#define EXTERN
 #include "rc.h"
+#undef EXTERN
+
 #include "exec.h"
 #include "io.h"
 #include "getflags.h"

--- a/rc/rc.h
+++ b/rc/rc.h
@@ -46,6 +46,10 @@ typedef struct builtin builtin;
 #pragma incomplete io
 #endif
 
+#ifndef EXTERN
+#define EXTERN extern
+#endif
+
 struct tree{
 	int	type;
 	int	rtype, fd0, fd1;	/* details of REDIR PIPE DUP tokens */
@@ -55,14 +59,14 @@ struct tree{
 	tree	*child[3];
 	tree	*next;
 };
-tree *newtree(void);
-tree *token(char*, int), *klook(char*), *tree1(int, tree*);
-tree *tree2(int, tree*, tree*), *tree3(int, tree*, tree*, tree*);
-tree *mung1(tree*, tree*), *mung2(tree*, tree*, tree*);
-tree *mung3(tree*, tree*, tree*, tree*), *epimung(tree*, tree*);
-tree *simplemung(tree*), *heredoc(tree*);
-void freetree(tree*);
-tree *cmdtree;
+EXTERN tree *newtree(void);
+EXTERN tree *token(char*, int), *klook(char*), *tree1(int, tree*);
+EXTERN tree *tree2(int, tree*, tree*), *tree3(int, tree*, tree*, tree*);
+EXTERN tree *mung1(tree*, tree*), *mung2(tree*, tree*, tree*);
+EXTERN tree *mung3(tree*, tree*, tree*, tree*), *epimung(tree*, tree*);
+EXTERN tree *simplemung(tree*), *heredoc(tree*);
+EXTERN void freetree(tree*);
+EXTERN tree *cmdtree;
 
 /*
  * The first word of any code vector is a reference count.
@@ -75,12 +79,12 @@ union code{
 	char	*s;
 };
 
-char *promptstr;
-int doprompt;
+EXTERN char *promptstr;
+EXTERN int doprompt;
 
 #define	NTOK	8192		/* maximum bytes in a word (token) */
 
-char tok[NTOK + UTFmax];
+EXTERN char tok[NTOK + UTFmax];
 
 #define	APPEND	1
 #define	WRITE	2
@@ -99,24 +103,24 @@ struct var{
 	int	pc;		/* pc of start of function */
 	var	*next;		/* next on hash or local list */
 };
-var *vlook(char*), *gvlook(char*), *newvar(char*, var*);
+EXTERN var *vlook(char*), *gvlook(char*), *newvar(char*, var*);
 
 #define	NVAR	521
 
-var *gvar[NVAR];		/* hash for globals */
+EXTERN var *gvar[NVAR];		/* hash for globals */
 
 #define	new(type)	((type *)emalloc(sizeof(type)))
 
-void *emalloc(long);
-void *Malloc(ulong);
-void efree(void *);
+EXTERN void *emalloc(long);
+EXTERN void *Malloc(ulong);
+EXTERN void efree(void *);
 
 struct here{
 	tree	*tag;
 	char	*name;
 	struct here *next;
 };
-int mypid;
+EXTERN int mypid;
 
 /*
  * Glob character escape in strings:
@@ -128,10 +132,10 @@ int mypid;
  */
 #define	GLOB	'\001'
 
-char **argp;
-char **args;
-int nerror;		/* number of errors encountered during compilation */
-int doprompt;		/* is it time for a prompt? */
+EXTERN char **argp;
+EXTERN char **args;
+EXTERN int nerror;		/* number of errors encountered during compilation */
+EXTERN int doprompt;		/* is it time for a prompt? */
 /*
  * Which fds are the reading/writing end of a pipe?
  * Unfortunately, this can vary from system to system.
@@ -141,12 +145,12 @@ int doprompt;		/* is it time for a prompt? */
 #define	PRD	0
 #define	PWR	1
 
-char *Rcmain, *Fdprefix;
+extern char *Rcmain, *Fdprefix;
 /*
  * How many dot commands have we executed?
  * Used to ensure that -v flag doesn't print rcmain.
  */
-int ndot;
-char *getstatus(void);
-int lastc;
-int lastword;
+EXTERN int ndot;
+EXTERN char *getstatus(void);
+EXTERN int lastc;
+EXTERN int lastword;

--- a/rc/rc.h
+++ b/rc/rc.h
@@ -80,7 +80,6 @@ union code{
 };
 
 EXTERN char *promptstr;
-EXTERN int doprompt;
 
 #define	NTOK	8192		/* maximum bytes in a word (token) */
 
@@ -153,4 +152,4 @@ extern char *Rcmain, *Fdprefix;
 EXTERN int ndot;
 EXTERN char *getstatus(void);
 EXTERN int lastc;
-EXTERN int lastword;
+extern int lastword;

--- a/rc/unix.c
+++ b/rc/unix.c
@@ -4,8 +4,9 @@
  *	upper case letter.
  */
 #include "rc.h"
-#include "io.h"
 #include "exec.h"
+#define EXTERN
+#include "io.h"
 #include "getflags.h"
 #include "fns.h"
 

--- a/rc/unix.c
+++ b/rc/unix.c
@@ -7,6 +7,7 @@
 #include "exec.h"
 #define EXTERN
 #include "io.h"
+#undef EXTERN
 #include "getflags.h"
 #include "fns.h"
 

--- a/tc/list.c
+++ b/tc/list.c
@@ -1,4 +1,4 @@
-#define	EXTERN
+#define	EXTERN extern
 #include "gc.h"
 
 void

--- a/tc/mul.c
+++ b/tc/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/utilities/hoc/hoc.y
+++ b/utilities/hoc/hoc.y
@@ -139,7 +139,7 @@ arglist:  /* nothing */ 	{ $$ = 0; }
 char	*progname;
 int	lineno = 1;
 jmp_buf	begin;
-int	indef;
+extern int	indef;
 char	*infile;	/* input file name */
 Biobuf	*bin;		/* input file descriptor */
 Biobuf	binbuf;

--- a/utilities/hoc/y.tab.c
+++ b/utilities/hoc/y.tab.c
@@ -62,7 +62,7 @@ YYSTYPE	yyval;
 char	*progname;
 int	lineno = 1;
 jmp_buf	begin;
-int	indef;
+extern int	indef;
 char	*infile;	/* input file name */
 Biobuf	*bin;		/* input file descriptor */
 Biobuf	binbuf;

--- a/vc/list.c
+++ b/vc/list.c
@@ -1,4 +1,4 @@
-#define EXTERN
+#define EXTERN extern
 #include "gc.h"
 
 void

--- a/vc/mul.c
+++ b/vc/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*

--- a/zc/list.c
+++ b/zc/list.c
@@ -1,4 +1,4 @@
-#define EXTERN
+#define EXTERN extern
 #include "gc.h"
 
 void

--- a/zc/mul.c
+++ b/zc/mul.c
@@ -1,3 +1,4 @@
+#define EXTERN
 #include "gc.h"
 
 /*


### PR DESCRIPTION
This fixes a lot of "multiple definition" linker errors when using GCC 10. Most of the fixes are sloppy and only meant to get it to work, not to be structured or look nice. I'm providing this in the current state to make it possible to use GCC 10, and intend to make it nicer later.